### PR TITLE
[TASK] Configure Travis for better performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
+sudo: false
+
 language: ruby
+
+cache: bundler
 
 rvm:
   - 1.9.3


### PR DESCRIPTION
* Set sudo: false. This allows Travis to use the new container-based
  infrastrukture, which should speed up the builds.

* Enable bundler caching.

Closes #9