### PR TITLE
[TASK] Drop support for Ruby 1.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Simple, internationalized and DRY page titles and headings for Rails.'
   s.description = 'Simple, internationalized and DRY page titles and headings for Rails.'
 
-  s.required_ruby_version     = '>= 1.9.3'
+  s.required_ruby_version     = '>= 2.0.0'
   s.required_rubygems_version = '>= 1.3.6'
 
   s.authors  = ['Lukas Westermann']


### PR DESCRIPTION
Ruby 1.9.3 was end-of-lifed on 2015-02-23.

Closes #24