### PR TITLE
[CLEANUP] Stop requiring version from the  main class

### DIFF
--- a/lib/page_title_helper.rb
+++ b/lib/page_title_helper.rb
@@ -7,7 +7,6 @@
 #
 # See documentation for +page_title+ for usage examples and more informations.
 require 'active_support'
-require 'page_title_helper/version'
 
 # PageTitleHelper
 module PageTitleHelper


### PR DESCRIPTION
It suffices to require the file from the gemspec file.

Fixes #43