### PR TITLE
Delete obselete init.rb file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ gemfile:
 
 script:
   - bundle exec rake --trace test
-  - bundle exec rubocop gemfiles/*.gemfile lib/ test/ Appraisals Gemfile init.rb Rakefile
+  - bundle exec rubocop gemfiles/*.gemfile lib/ test/ Appraisals Gemfile Rakefile
 
 matrix:
   fast_finish: true

--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,0 @@
-require 'page_title_helper'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 require 'active_support'
 require 'action_view'
-require File.join(File.dirname(__FILE__), '..', 'init')
+require 'page_title_helper'
 
 unless defined?(IRB)
   require 'active_support/test_case'


### PR DESCRIPTION
The init.rb file dates back to Rails 2 plugins, if I recall correctly.

Fixes #57