### PR TITLE
Update rubocop to .49 to fix dev vuln

### DIFF
--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '>= 10.3.2'
   s.add_development_dependency 'shoulda'
-  s.add_development_dependency 'rubocop', '~> 0.47.1'
+  s.add_development_dependency 'rubocop', '~> 0.49.0'
 end

--- a/test/multiple_formats_test.rb
+++ b/test/multiple_formats_test.rb
@@ -13,7 +13,7 @@ class MultipleFormatsTest < ActiveSupport::TestCase
     end
 
     should 'still return title as string and not the array' do
-      assert_equal 'Oh my...!', @view.page_title { ['Oh my...!', ':title // :app'] }
+      assert_equal('Oh my...!', @view.page_title { ['Oh my...!', ':title // :app'] })
     end
   end
 
@@ -33,18 +33,18 @@ class MultipleFormatsTest < ActiveSupport::TestCase
     end
 
     should 'fallback to default format, if array is not big enough (i.e. only contains single element...)' do
-      assert_equal 'Test', @view.page_title { ['Test'] }
+      assert_equal('Test', @view.page_title { ['Test'] })
       assert_equal 'Test - Page title helper', @view.page_title
     end
 
     context 'used with the array block' do
       should 'also allow aliases returned in that array thingy' do
-        assert_equal 'Test', @view.page_title { ['Test', :myformat] }
+        assert_equal('Test', @view.page_title { ['Test', :myformat] })
         assert_equal 'Test <-> Page title helper', @view.page_title
       end
 
       should 'override locally supplied :format arguments' do
-        assert_equal 'Something', @view.page_title { ['Something', '* * * :title * * *'] }
+        assert_equal('Something', @view.page_title { ['Something', '* * * :title * * *'] })
         assert_equal '* * * Something * * *', @view.page_title(format: '-= :title =-') # yeah, using x-tra ugly titles :)
       end
     end

--- a/test/page_title_helper_test.rb
+++ b/test/page_title_helper_test.rb
@@ -36,12 +36,12 @@ class PageTitleHelperTest < ActiveSupport::TestCase
 
     context '#page_title (define w/ block)' do
       should 'return title from block and render with app name' do
-        assert_equal 'foo', @view.page_title { 'foo' }
+        assert_equal('foo', @view.page_title { 'foo' })
         assert_equal 'foo - Page title helper', @view.page_title
       end
 
       should 'set custom title using a translation with a placeholder' do
-        assert_equal 'Displaying Bella', @view.page_title { I18n.t(:placeholder, name: 'Bella') }
+        assert_equal('Displaying Bella', @view.page_title { I18n.t(:placeholder, name: 'Bella') })
         assert_equal 'Displaying Bella - Page title helper', @view.page_title
       end
     end
@@ -73,13 +73,13 @@ class PageTitleHelperTest < ActiveSupport::TestCase
       end
 
       should 'use custom format, if :format option is defined' do
-        assert_equal 'test', @view.page_title { 'test' }
+        assert_equal('test', @view.page_title { 'test' })
         assert_equal 'Some app :: test', @view.page_title(app: 'Some app', format: ':app :: :title')
         assert_equal 'Some app / test', @view.page_title(format: 'Some app / :title')
       end
 
       should 'return just title if format: false is passed' do
-        assert_equal 'untitled', @view.page_title { 'untitled' }
+        assert_equal('untitled', @view.page_title { 'untitled' })
         assert_equal 'untitled', @view.page_title(format: false)
       end
 


### PR DESCRIPTION
Was only potentially impacting development and not any running instances or usages of the gem. In addition had to update a few tests as rubocop 0.49  complained about missing parentheses.

FYI, upgrade to version 0.5x of rubocop is only possible when we drop support for Ruby 2.0.

@oliverklee please review and merge, thanks.