### PR TITLE
[TASK] Drop support for Ruby < 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.4
 Style/FileName:
   Exclude:
     - 'gemfiles/Gemfile.*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2.10
-  - 2.3.8
   - 2.4.7
   - 2.5.6
   - 2.6.4
@@ -34,21 +30,5 @@ script:
 matrix:
   fast_finish: true
   exclude:
-    - gemfile: Gemfile
-      rvm: 2.0.0
-    - gemfile: Gemfile
-      rvm: 2.1
     - gemfile: gemfiles/Gemfile.rails-4-2
       rvm: ruby-head
-    - gemfile: gemfiles/Gemfile.rails-5-0
-      rvm: 2.0.0
-    - gemfile: gemfiles/Gemfile.rails-5-0
-      rvm: 2.1
-    - gemfile: gemfiles/Gemfile.rails-5-1
-      rvm: 2.0.0
-    - gemfile: gemfiles/Gemfile.rails-5-1
-      rvm: 2.1
-    - gemfile: gemfiles/Gemfile.rails-5-2
-      rvm: 2.0.0
-    - gemfile: gemfiles/Gemfile.rails-5-2
-      rvm: 2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ about why a change log is important.
 
 
 ### Removed
+- Drop support for Ruby < 2.4
+  ([#93](https://github.com/lwe/page_title_helper/pull/93))
 - Drop support for Rails 3.2 and 4.0
   ([#39](https://github.com/lwe/page_title_helper/pull/39))
 - Drop support for Ruby 1.9.x

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'rake/testtask'
 

--- a/gemfiles/Gemfile.rails-4-2
+++ b/gemfiles/Gemfile.rails-4-2
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'rails', '~> 4.2.0'

--- a/gemfiles/Gemfile.rails-5-0
+++ b/gemfiles/Gemfile.rails-5-0
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0.0'

--- a/gemfiles/Gemfile.rails-5-1
+++ b/gemfiles/Gemfile.rails-5-1
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.1.0'

--- a/gemfiles/Gemfile.rails-5-2
+++ b/gemfiles/Gemfile.rails-5-2
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.2.0'

--- a/lib/page_title_helper.rb
+++ b/lib/page_title_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # PageTitleHelper provides an +ActionView+ helper method to simplify adding
 # custom titles to pages.
 #

--- a/lib/page_title_helper/version.rb
+++ b/lib/page_title_helper/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PageTitleHelper
   VERSION = '3.0.0'.freeze
 end

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Simple, internationalized and DRY page titles and headings for Rails.'
   s.description = 'Simple, internationalized and DRY page titles and headings for Rails.'
 
-  s.required_ruby_version     = '>= 2.0.0'
+  s.required_ruby_version     = '>= 2.4.0'
   s.required_rubygems_version = '>= 1.3.6'
 
   s.authors  = ['Lukas Westermann']

--- a/test/multiple_formats_test.rb
+++ b/test/multiple_formats_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'test_helper'
 

--- a/test/page_title_helper_test.rb
+++ b/test/page_title_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require 'test_helper'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support'
 require 'action_view'
 require 'page_title_helper'


### PR DESCRIPTION
Ruby 2.3 has reached its end of life:
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/