### PR TITLE
[TASK] Drop support for Rails < 5.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   TargetRubyVersion: 2.4
+  TargetRailsVersion: 5.2
 Style/FileName:
   Exclude:
     - 'gemfiles/Gemfile.*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ rvm:
 
 gemfile:
   - Gemfile
-  - gemfiles/Gemfile.rails-4-2
-  - gemfiles/Gemfile.rails-5-0
-  - gemfiles/Gemfile.rails-5-1
   - gemfiles/Gemfile.rails-5-2
   - gemfiles/Gemfile.rails-6.0
 
@@ -25,16 +22,11 @@ install:
 script:
   - bundle exec rake --trace test
   - bundle exec rubocop --rails Gemfile \
-    gemfiles/Gemfile.rails-4-2 gemfiles/Gemfile.rails-5-0 \
-    gemfiles/Gemfile.rails-5-1 gemfiles/Gemfile.rails-5-2 \
-    gemfiles/Gemfile.rails-6.0 lib/ test/ Rakefile
+    gemfiles/Gemfile.rails-5-2 \ gemfiles/Gemfile.rails-6.0 \
+    lib/ test/ Rakefile
 
 matrix:
   fast_finish: true
   exclude:
-    - gemfile: gemfiles/Gemfile.rails-4-2
-      rvm: ruby-head
-    - gemfile: gemfiles/Gemfile.rails-4-2
-      rvm: 2.7.0
     - gemfile: gemfiles/Gemfile.rails-6.0
       rvm: 2.4.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ about why a change log is important.
 ### Deprecated
 
 ### Removed
+- Drop support for Rails < 5.2
+  ([#104](https://github.com/lwe/page_title_helper/pull/104))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## What does this gem do?
 
-Ever wondered if there was an easier and DRY-way to set your page titles (and/or headings),
-introducing _page title helper_, a small view helper for Rails 4.2 and 5
-to inflect titles from controllers and actions.
+Ever wondered if there was an easier and DRY-way to set your page titles
+(and/or headings), introducing _page title helper_, a small view helper for
+Rails to inflect titles from controllers and actions.
 
 In your layout, add this to your `<head>`-section:
 

--- a/gemfiles/Gemfile.rails-4-2
+++ b/gemfiles/Gemfile.rails-4-2
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 4.2.11'
-gem 'nokogiri', '<1.7.0'
-
-gemspec path: '../'

--- a/gemfiles/Gemfile.rails-5-0
+++ b/gemfiles/Gemfile.rails-5-0
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 5.0.7.2'
-
-gemspec path: '../'

--- a/gemfiles/Gemfile.rails-5-1
+++ b/gemfiles/Gemfile.rails-5-1
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 5.1.7'
-
-gemspec path: '../'

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.license          = 'MIT'
 
-  s.add_dependency 'rails', '>= 4.2.0', '< 6.1'
+  s.add_dependency 'rails', '>= 5.2.0', '< 6.1'
 
   s.add_development_dependency 'rake', '>= 10.3.2'
   s.add_development_dependency 'shoulda'


### PR DESCRIPTION
All Rails versions below 5.2 have reached their end of life.