### PR TITLE
[CLEANUP] Fix warnings in the .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+os: linux
 
 language: ruby
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ about why a change log is important.
   ([#104](https://github.com/lwe/page_title_helper/pull/104))
 
 ### Fixed
+- Fix warnings in the `.travis.yml`
+  ([#106](https://github.com/lwe/page_title_helper/pull/106))
 
 ### Security
 


### PR DESCRIPTION
- drop the obsolete `sudo` option
- make the `os` option explicit