### PR TITLE
[CLEANUP] Fix notices in the .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 os: linux
 
+dist: bionic
+
 language: ruby
 
 cache: bundler
@@ -25,7 +27,7 @@ script:
     gemfiles/Gemfile.rails-5-2 \ gemfiles/Gemfile.rails-6.0 \
     lib/ test/ Rakefile
 
-matrix:
+jobs:
   fast_finish: true
   exclude:
     - gemfile: gemfiles/Gemfile.rails-6.0


### PR DESCRIPTION
- explicitly set the Linux distribution
- replace the alias `matrix` with `jobs`