### PR TITLE
[TASK] Drop support for Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.4.10
   - 2.5.8
   - 2.6.6
   - 2.7.1
@@ -29,6 +28,3 @@ script:
 
 jobs:
   fast_finish: true
-  exclude:
-    - gemfile: gemfiles/Gemfile.rails-6.0
-      rvm: 2.4.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ about why a change log is important.
 ### Deprecated
 
 ### Removed
+- Drop support for Ruby 2.4
+  ([#109](https://github.com/lwe/page_title_helper/pull/109))
 - Drop support for Rails < 5.2
   ([#104](https://github.com/lwe/page_title_helper/pull/104))
 

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -9,8 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Simple, internationalized and DRY page titles and headings for Rails.'
   s.description = 'Simple, internationalized and DRY page titles and headings for Rails.'
 
-  s.required_ruby_version     = '>= 2.4.0'
-  s.required_rubygems_version = '>= 1.3.6'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.authors  = ['Lukas Westermann']
   s.email    = ['lukas.westermann@gmail.com']


### PR DESCRIPTION
Ruby 2.4 has reached its end of life:
https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

Also drop the rubygems version requirement as this gem does not
depend on this.