### PR TITLE
[BUGFIX] Security-update Ruby to 2.7.2 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache: bundler
 rvm:
   - 2.5.8
   - 2.6.6
-  - 2.7.1
+  - 2.7.2
   - ruby-head
 
 gemfile:


### PR DESCRIPTION
CVE-2020-25613