### PR TITLE
[BUGFIX] Use a maintained action for installing Ruby for the CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 'Set up Ruby'
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0.0'
       - name: 'Check the environment'
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: 'Set up Ruby'
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '${{ matrix.ruby }}'
       - name: 'Check the environment'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ about why a change log is important.
 - Drop support for Rails < 5.2 (#104)
 
 ### Fixed
+- Use a better-maintained Ruby setup for the CI (#121)
 - Fix warnings in the `.travis.yml` (#106)
 
 ### Security


### PR DESCRIPTION
`ruby/setup-ruby` is the better action to use for installing Ruby
in GitHub Actions (particularly for more recent Ruby versions);
`actions/setup-ruby` is not.