### PR TITLE
[FEATURE] Add automatic gem release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+---
+name: 'Publish'
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: 'Publish to RubyGems'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: 'Set up Ruby'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0.0'
+
+      - name: 'Publish to RubyGems'
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build page_title_helper.gemspec
+          gem push page_title_helper-*.gem
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ about why a change log is important.
 ## x.y.z
 
 ### Added
+- Add automatic gem release (#122)
 - Add support for Rails 6.1 (#113, #114)
 - Officially support Ruby 2.7 (#103)
 


### PR DESCRIPTION
This new GitHub Actions workflow will automatically publish the
gem to RubyGems when a new release is tagged with the `v` prefix,
e.g., `v5.0.0`.

For authentication, there needs to be a secret with the key
`RUBYGEMS_API_KEY` configured in the GitHub repository configuration.
The stored rubygems.org API key needs to have gem publication permissions,
and two-factor authentication for the corresponding rubygems.org account
should only be enabled for the UI, but must not be enabled for the API
(as there is no way to enter the second factor when the GitHub action
is run).