### PR TITLE
[TASK] Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.5.8'
           - '2.6.6'
           - '2.7.2'
           - '3.0.0'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   TargetRailsVersion: 5.2
 
 Layout/IndentationConsistency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ about why a change log is important.
 ### Deprecated
 
 ### Removed
+- Drop support for Ruby 2.5 (#127)
 
 ### Fixed
 

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Simple, internationalized and DRY page titles and headings for Rails.'
   s.description = 'Simple, internationalized and DRY page titles and headings for Rails.'
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
 
   s.authors  = ['Lukas Westermann']
   s.email    = ['lukas.westermann@gmail.com']


### PR DESCRIPTION
Ruby 2.5 has reached its EOL.