### PR TITLE
[TASK] Explicitly set all values in the CI build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby:
-          - '2.6.9'
-          - '2.7.5'
-          - '3.0.3'
-        rails:
-          - '5.2'
-          - '6.0'
-          - '6.1'
+        include:
+          - { 'rails': '5.2', 'ruby': '2.6.9' }
+          - { 'rails': '5.2', 'ruby': '2.7.5' }
+          - { 'rails': '5.2', 'ruby': '3.0.3' }
+          - { 'rails': '6.0', 'ruby': '2.6.9' }
+          - { 'rails': '6.0', 'ruby': '2.7.5' }
+          - { 'rails': '6.0', 'ruby': '3.0.3' }
+          - { 'rails': '6.1', 'ruby': '2.6.9' }
+          - { 'rails': '6.1', 'ruby': '2.7.5' }
+          - { 'rails': '6.1', 'ruby': '3.0.3' }


### PR DESCRIPTION
This will allow us to have combinations in the future that exclude
some elements of the cross product between all possible Ruby and Rails
versions (e.g., use Ruby 3.1 builds only with newer Rails versions).