### PR TITLE
[CLEANUP] Drop redundant RuboCop rule switches

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,23 +11,7 @@ AllCops:
 
 Layout/IndentationConsistency:
   EnforcedStyle: indented_internal_methods
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-Lint/StructNewOverride:
-  Enabled: true
 
 Naming/FileName:
   Exclude:
     - 'gemfiles/Gemfile.*'
-
-Style/ExponentialNotation:
-  Enabled: true
-Style/HashEachMethods:
-  Enabled: true
-Style/HashTransformKeys:
-  Enabled: true
-Style/HashTransformValues:
-  Enabled: true


### PR DESCRIPTION
Now that all rules are enabled by default, we do not need
to enable the rules individually anymore.