### PR TITLE
[TASK] Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,15 +61,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '5.2', 'ruby': '2.6.9' }
           - { 'rails': '5.2', 'ruby': '2.7.5' }
           - { 'rails': '5.2', 'ruby': '3.0.3' }
           - { 'rails': '5.2', 'ruby': '3.1.1' }
-          - { 'rails': '6.0', 'ruby': '2.6.9' }
           - { 'rails': '6.0', 'ruby': '2.7.5' }
           - { 'rails': '6.0', 'ruby': '3.0.3' }
           - { 'rails': '6.0', 'ruby': '3.1.1' }
-          - { 'rails': '6.1', 'ruby': '2.6.9' }
           - { 'rails': '6.1', 'ruby': '2.7.5' }
           - { 'rails': '6.1', 'ruby': '3.0.3' }
           - { 'rails': '6.1', 'ruby': '3.1.1' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   TargetRailsVersion: 5.2
   NewCops: enable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ about why a change log is important.
 ### Deprecated
 
 ### Removed
-- Drop support for Ruby 2.5 (#127)
+- Drop support for Ruby 2.5 and 2.6 (#127, #145)
 
 ### Fixed
 - Avoid modifying a frozen array in Ruby 3 (#135)

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Simple, internationalized and DRY page titles and headings for Rails.'
   s.description = 'Simple, internationalized and DRY page titles and headings for Rails.'
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.authors  = ['Lukas Westermann']
   s.email    = ['lukas.westermann@gmail.com']


### PR DESCRIPTION
The EOL of Ruby 2.6 is 2022-03-31:
https://www.ruby-lang.org/en/downloads/branches/

Fixes #136