### PR TITLE
[TASK] Limit the runtime of the CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   static-analysis:
     name: 'Static analysis'
     runs-on: ubuntu-22.04
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v3
       - name: 'Set up Ruby'
@@ -36,6 +37,7 @@ jobs:
   test:
     name: "Tests: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}"
     runs-on: ubuntu-22.04
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v3
       - name: 'Set up Ruby'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: 'Publish to RubyGems'
     runs-on: ubuntu-22.04
+    timeout-minutes: 3
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
This keeps stuck jobs from unnecessarily hogging CI resources.