### PR TITLE
[TASK] Drop support for Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,19 +64,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '5.2', 'ruby': '2.7.8' }
           - { 'rails': '5.2', 'ruby': '3.0.6' }
           - { 'rails': '5.2', 'ruby': '3.1.4' }
           - { 'rails': '5.2', 'ruby': '3.2.2' }
-          - { 'rails': '6.0', 'ruby': '2.7.8' }
           - { 'rails': '6.0', 'ruby': '3.0.6' }
           - { 'rails': '6.0', 'ruby': '3.1.4' }
           - { 'rails': '6.0', 'ruby': '3.2.2' }
-          - { 'rails': '6.1', 'ruby': '2.7.8' }
           - { 'rails': '6.1', 'ruby': '3.0.6' }
           - { 'rails': '6.1', 'ruby': '3.1.4' }
           - { 'rails': '6.1', 'ruby': '3.2.2' }
-          - { 'rails': '7.0', 'ruby': '2.7.8' }
           - { 'rails': '7.0', 'ruby': '3.0.6' }
           - { 'rails': '7.0', 'ruby': '3.1.4' }
           - { 'rails': '7.0', 'ruby': '3.2.2' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   TargetRailsVersion: 5.2
   NewCops: enable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ about why a change log is important.
 ### Deprecated
 
 ### Removed
+- Drop support for Ruby 2.7 (#163)
 
 ### Fixed
 

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Simple, internationalized and DRY page titles and headings for Rails.'
   s.description = 'Simple, internationalized and DRY page titles and headings for Rails.'
 
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.0.0'
 
   s.authors  = ['Lukas Westermann']
   s.email    = ['lukas.westermann@gmail.com']


### PR DESCRIPTION
Ruby 2.7 is EOL now:
https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/