### PR TITLE
[TASK] Drop support for Rails 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: 'Run RuboCop'
         run: |
           bundle exec rubocop Gemfile \
-            gemfiles/Gemfile.rails-5.2 gemfiles/Gemfile.rails-6.0 \
+            gemfiles/Gemfile.rails-6.0 \
             gemfiles/Gemfile.rails-6.1 gemfiles/Gemfile.rails-7.0 \
             lib/ test/ Rakefile
   test:
@@ -64,9 +64,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '5.2', 'ruby': '3.0.6' }
-          - { 'rails': '5.2', 'ruby': '3.1.4' }
-          - { 'rails': '5.2', 'ruby': '3.2.2' }
           - { 'rails': '6.0', 'ruby': '3.0.6' }
           - { 'rails': '6.0', 'ruby': '3.1.4' }
           - { 'rails': '6.0', 'ruby': '3.2.2' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.0
-  TargetRailsVersion: 5.2
+  TargetRailsVersion: 6.0
   NewCops: enable
 
 Layout/IndentationConsistency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ about why a change log is important.
 ### Deprecated
 
 ### Removed
+- Drop support for Rails 5.2 (#164)
 - Drop support for Ruby 2.7 (#163)
 
 ### Fixed

--- a/gemfiles/Gemfile.rails-5.2
+++ b/gemfiles/Gemfile.rails-5.2
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 5.2.4.4'
-
-gemspec path: '../'

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.license          = 'MIT'
 
-  s.add_dependency 'rails', '>= 5.2.0', '< 7.1'
+  s.add_dependency 'rails', '>= 6.0.0', '< 7.1'
 
   s.add_development_dependency 'rake', '~> 13.0.6'
   s.add_development_dependency 'rubocop', '~> 1.26.1'


### PR DESCRIPTION
Rails 5.2 is EOL now:
https://endoflife.date/rails

Fixes #137