### PR TITLE
[FEATURE] Add official support for Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 'Set up Ruby'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.2'
+          ruby-version: '3.3.0'
       - name: 'Check the environment'
         run: |
           ruby --version
@@ -67,9 +67,12 @@ jobs:
           - { 'rails': '6.1', 'ruby': '3.0.6' }
           - { 'rails': '6.1', 'ruby': '3.1.4' }
           - { 'rails': '6.1', 'ruby': '3.2.2' }
+          - { 'rails': '6.1', 'ruby': '3.3.0' }
           - { 'rails': '7.0', 'ruby': '3.0.6' }
           - { 'rails': '7.0', 'ruby': '3.1.4' }
           - { 'rails': '7.0', 'ruby': '3.2.2' }
+          - { 'rails': '7.0', 'ruby': '3.3.0' }
           - { 'rails': '7.1', 'ruby': '3.0.6' }
           - { 'rails': '7.1', 'ruby': '3.1.4' }
           - { 'rails': '7.1', 'ruby': '3.2.2' }
+          - { 'rails': '7.1', 'ruby': '3.3.0' }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ about why a change log is important.
 ## x.y.z
 
 ### Added
+- Add official support for Ruby 3.3 (#177)
 
 ### Changed
 


### PR DESCRIPTION
Also switch the code quality CI job to Ruby 3.3.

The gem publication CI job stays at Ruby 3.2 for now (to play it safe).

Fixes #176