### PR TITLE
[TASK] Drop support for Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,15 +64,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '6.1', 'ruby': '3.0.7' }
           - { 'rails': '6.1', 'ruby': '3.1.5' }
           - { 'rails': '6.1', 'ruby': '3.2.4' }
           - { 'rails': '6.1', 'ruby': '3.3.1' }
-          - { 'rails': '7.0', 'ruby': '3.0.7' }
           - { 'rails': '7.0', 'ruby': '3.1.5' }
           - { 'rails': '7.0', 'ruby': '3.2.4' }
           - { 'rails': '7.0', 'ruby': '3.3.1' }
-          - { 'rails': '7.1', 'ruby': '3.0.7' }
           - { 'rails': '7.1', 'ruby': '3.1.5' }
           - { 'rails': '7.1', 'ruby': '3.2.4' }
           - { 'rails': '7.1', 'ruby': '3.3.1' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   TargetRailsVersion: 6.1
   NewCops: enable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ about why a change log is important.
 ### Deprecated
 
 ### Removed
+- Drop support for Ruby 3.0 (#184)
 
 ### Fixed
 

--- a/lib/page_title_helper.rb
+++ b/lib/page_title_helper.rb
@@ -34,8 +34,8 @@ module PageTitleHelper
   end
 
   # Add new, custom, interpolation.
-  def self.interpolates(key, &block)
-    Interpolations.send(:define_method, key, &block)
+  def self.interpolates(key, &)
+    Interpolations.send(:define_method, key, &)
   end
 
   # Default options, which are globally referenced and can
@@ -75,7 +75,7 @@ module PageTitleHelper
     format = PageTitleHelper.formats[format] if PageTitleHelper.formats.include?(format)
 
     # construct basic env to pass around
-    env = { title: real_title, app: options[:app], options: options, view: self }
+    env = { title: real_title, app: options[:app], options:, view: self }
 
     # interpolate format
     Interpolations.interpolate(format, env)

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Simple, internationalized and DRY page titles and headings for Rails.'
   s.description = 'Simple, internationalized and DRY page titles and headings for Rails.'
 
-  s.required_ruby_version = '>= 3.0.0'
+  s.required_ruby_version = '>= 3.1.0'
 
   s.authors  = ['Lukas Westermann']
   s.email    = ['lukas.westermann@gmail.com']


### PR DESCRIPTION
Ruby 3.0 has been EOL'ed:
https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/

Also make use of some Ruby 3.1 features.

Fixes #181