### PR TITLE
[TASK] Drop support for Rails 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: 'Run RuboCop'
         run: |
           bundle exec rubocop Gemfile \
-            gemfiles/Gemfile.rails-7.1 gemfiles/Gemfile.rails-7.2 \
+            gemfiles/Gemfile.rails-7.2 \
             gemfiles/Gemfile.rails-8.0 lib/ test/ Rakefile
 
   test:
@@ -55,9 +55,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '7.1', 'ruby': '3.2.8' }
-          - { 'rails': '7.1', 'ruby': '3.3.8' }
-          - { 'rails': '7.1', 'ruby': '3.4.6' }
           - { 'rails': '7.2', 'ruby': '3.2.8' }
           - { 'rails': '7.2', 'ruby': '3.3.8' }
           - { 'rails': '7.2', 'ruby': '3.4.6' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.2
-  TargetRailsVersion: 7.1
+  TargetRailsVersion: 7.2
   NewCops: enable
 
 Layout/IndentationConsistency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ about why a change log is important.
 ### Removed
 
 - Drop support for Ruby 3.1 (#219)
-- Drop support for Rails 7.0 (#218, #220)
+- Drop support for Rails 7.0 and 7.1 (#218, #220, #228)
 
 ### Fixed
 

--- a/gemfiles/Gemfile.rails-7.1
+++ b/gemfiles/Gemfile.rails-7.1
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 7.1.0'
-
-gemspec path: '../'

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.license          = 'MIT'
 
-  s.add_dependency 'rails', '>= 7.1.0', '< 8.1'
+  s.add_dependency 'rails', '>= 7.2.0', '< 8.1'
 
   s.add_development_dependency 'rake', '~> 13.2.1'
   s.add_development_dependency 'rubocop', '~> 1.69.2'


### PR DESCRIPTION
Rails 7.1 will be EOL on October 1st, 2025.

https://endoflife.date/rails