### PR TITLE
[TASK] Drop support for Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '7.2', 'ruby': '3.2.10' }
           - { 'rails': '7.2', 'ruby': '3.3.10' }
           - { 'rails': '7.2', 'ruby': '3.4.9' }
           - { 'rails': '7.2', 'ruby': '4.0.2' }
-          - { 'rails': '8.0', 'ruby': '3.2.10' }
           - { 'rails': '8.0', 'ruby': '3.3.10' }
           - { 'rails': '8.0', 'ruby': '3.4.9' }
           - { 'rails': '8.0', 'ruby': '4.0.2' }
-          - { 'rails': '8.1', 'ruby': '3.2.10' }
           - { 'rails': '8.1', 'ruby': '3.3.10' }
           - { 'rails': '8.1', 'ruby': '3.4.9' }
           - { 'rails': '8.1', 'ruby': '4.0.2' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   TargetRailsVersion: 7.2
   NewCops: enable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ about why a change log is important.
 
 ### Removed
 
+- Drop support for Ruby 3.2 (#246)
+
 ### Fixed
 
 ### Security

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Simple, internationalized and DRY page titles and headings for Rails.'
   s.description = 'Simple, internationalized and DRY page titles and headings for Rails.'
 
-  s.required_ruby_version = '>= 3.2.0'
+  s.required_ruby_version = '>= 3.3.0'
 
   s.authors  = ['Lukas Westermann']
   s.email    = ['lukas.westermann@gmail.com']


### PR DESCRIPTION
Ruby 3.2 is EOL:

https://endoflife.date/ruby

Fixes #242