### PR TITLE
[TASK] Increase the Dependabot cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This increases supply-chain security by increasing the time window in which we block updates to allow insecure versions to get pull.

https://docs.zizmor.sh/audits/#dependabot-cooldown