### PR TITLE
[TASK] Drop support for Rails 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: 'Run RuboCop'
         run: |
           bundle exec rubocop Gemfile \
-            gemfiles/Gemfile.rails-7.2 gemfiles/Gemfile.rails-8.0 \
+            gemfiles/Gemfile.rails-8.0 \
             gemfiles/Gemfile.rails-8.1 lib/ test/ Rakefile
 
   test:
@@ -61,9 +61,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { 'rails': '7.2', 'ruby': '3.3.12' }
-          - { 'rails': '7.2', 'ruby': '3.4.10' }
-          - { 'rails': '7.2', 'ruby': '4.0.6' }
           - { 'rails': '8.0', 'ruby': '3.3.12' }
           - { 'rails': '8.0', 'ruby': '3.4.10' }
           - { 'rails': '8.0', 'ruby': '4.0.6' }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.3
-  TargetRailsVersion: 7.2
+  TargetRailsVersion: 8.0
   NewCops: enable
 
 Layout/IndentationConsistency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ about why a change log is important.
 
 ### Removed
 
+- Drop support for Rails 7.2 (#264)
 - Drop support for Ruby 3.2 (#246)
 
 ### Fixed

--- a/gemfiles/Gemfile.rails-7.2
+++ b/gemfiles/Gemfile.rails-7.2
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-
-gem 'rails', '~> 7.2.0'
-
-gemspec path: '../'

--- a/page_title_helper.gemspec
+++ b/page_title_helper.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.license          = 'MIT'
 
-  s.add_dependency 'rails', '>= 7.2.0', '< 8.2'
+  s.add_dependency 'rails', '>= 8.0.0', '< 8.2'
 
   s.add_development_dependency 'rake', '~> 13.4.2'
   s.add_development_dependency 'rubocop', '~> 1.90.0'


### PR DESCRIPTION
Rails 7.2 reached EOL on 2026-08-09.

https://endoflife.date/rails

Fixes #243